### PR TITLE
Compatibility with other cluster modules; client.getMetrics() same as server.getMetrics()

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,7 @@
-# cluster-metrics
+# cluster-metrics2
+
+(forked from [LeanKit-Labs' `cluster-metrics`](https://github.com/LeanKit-Labs/cluster-metrics), which appears no longer maintained)
+
 It's fun to put 'cluster' in front of things. It's also fun when you can aggregate all your metrics in a cluster into a single metrics report.
 
 This lib provides a uniform api between workers and a main process within a Node cluster for collecting metrics. Collection is done via the [metrics lib in use at Yammer](https://github.com/mikejihbe/metrics), a clone of Coda's Java Metrics library.
@@ -8,7 +11,7 @@ Fwiw - you may not WANT this behavior, in which case, simply use the metrics lib
 ## Use
 No matter if you're on master or a worker, simply require it and go:
 ```javascript
-var metrics = require( 'cluster-metrics' );
+var metrics = require( 'cluster-metrics2' );
 ```
 
 ## API

--- a/package.json
+++ b/package.json
@@ -19,5 +19,12 @@
     "metrics"
   ],
   "author": "Alex Robson",
-  "license": "MIT License - http://opensource.org/licenses/MIT"
+  "license": "MIT License - http://opensource.org/licenses/MIT",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/LeanKit-Labs/cluster-metrics.git"
+  },
+  "bugs": {
+    "url": "https://github.com/LeanKit-Labs/cluster-metrics/issues"
+  }
 }

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "A very simple way to centralize metrics collected in a node cluster",
   "main": "src/index.js",
   "dependencies": {
-    "lodash": "~2.4.1",
+    "lodash": "^4.17.5",
     "metrics": "~0.1.9",
     "postal": "~1.0.1"
   },
@@ -13,8 +13,7 @@
     "gulp-mocha": "~0.4.1",
     "processhost": "~0.1.9"
   },
-  "scripts": {
-  },
+  "scripts": {},
   "keywords": [
     "metrics"
   ],

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "cluster-metrics",
+  "name": "cluster-metrics2",
   "version": "0.0.2",
   "description": "A very simple way to centralize metrics collected in a node cluster",
   "main": "src/index.js",
@@ -21,9 +21,9 @@
   "license": "MIT License - http://opensource.org/licenses/MIT",
   "repository": {
     "type": "git",
-    "url": "https://github.com/LeanKit-Labs/cluster-metrics.git"
+    "url": "https://github.com/nicjansma/cluster-metrics2.git"
   },
   "bugs": {
-    "url": "https://github.com/LeanKit-Labs/cluster-metrics/issues"
+    "url": "https://github.com/nicjansma/cluster-metrics2/issues"
   }
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cluster-metrics2",
-  "version": "0.0.2",
+  "version": "0.0.3",
   "description": "A very simple way to centralize metrics collected in a node cluster",
   "main": "src/index.js",
   "dependencies": {

--- a/src/client.js
+++ b/src/client.js
@@ -18,7 +18,7 @@ var MB = 1024 * 1024,
 			delete metrics.clustermetrics;
 
 			_.each( waiting, function( callback ) {
-				callback( metrics );
+				callback( metrics.report );
 			} );
 			waiting = [];
 		} );

--- a/src/client.js
+++ b/src/client.js
@@ -6,10 +6,17 @@ var MB = 1024 * 1024,
 	client = function() {
 		var waiting = [],
 			send = function( type, message ) {
-				process.send(  { type: type, message: message } ) ;
+				process.send(  { clustermetrics: true, type: type, message: message } ) ;
 			};
 
 		process.on( 'message', function( metrics ) {
+			// ensure this message is for us
+			if ( !metrics.clustermetrics ) {
+				return;
+			}
+
+			delete metrics.clustermetrics;
+
 			_.each( waiting, function( callback ) {
 				callback( metrics );
 			} );

--- a/src/server.js
+++ b/src/server.js
@@ -63,7 +63,10 @@ var MB = 1024 * 1024,
 				delete data.clustermetrics;
 
 				if( data.type == 'report' ) {
-					worker.send( { clustermetrics: true, type: 'report', report: report.summary() } );
+					report.getMetrics(function(metrics) {
+						var data = _.merge( metrics, report.summary() );
+						worker.send( { clustermetrics: true, type: 'report', report: data } );
+					});
 				} else if ( data.type == 'memory' ) {
 					memoryList[ worker.id ] = data.message;
 				} else {


### PR DESCRIPTION
This fixes three things:

1. The module would get confused if there were other cluster modules being used (e.g. `node-cluster-cache`) that also sent IPC messages.  This change adds a property `.clustermetrics` to the message and both client/server ensure that property exists before processing.

2. Calling `report.getMetrics()` from the client gave a completely different result than from the server.  On the server, you would get the metrics report + memory/load metrics (`memoryUtilization`).  On the client, you would get the IPC message (so it would look like `{ type: "report", report: {} }` and would be missing all of the memory/load metrics.  I've changed the client callback to look the same as the server.

3. Added repo information to the `package.json`.  I had a hard time finding this repo from npm since it wasn't listed.